### PR TITLE
add: show changes like current branch

### DIFF
--- a/git-completion.bash
+++ b/git-completion.bash
@@ -87,10 +87,11 @@ __git_ps1 ()
 __git_ps1_changes ()
 {
 	local b_ref="$(git symbolic-ref HEAD 2>/dev/null)";
+    local b_origin="$(git for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD))";
 	if [ -n "$b_ref" ]; then
 		local b=${b_ref##refs/heads/};
 		local changes="";
-		local unpush=$(git rev-list origin/$b..$b --count);
+		local unpush=$(git rev-list $b_origin..$b --count);
 		local staged=$(git diff --staged --name-status | wc -l);
 		local uncommits=$(git status -s -uall --porcelain);
 

--- a/git-completion.bash
+++ b/git-completion.bash
@@ -96,7 +96,7 @@ __git_ps1_changes ()
 		local uncommits=$(git status -s -uall --porcelain);
 
 		if (( $unpush > 0 )); then
-			changes="$changes ▵$unpush"
+			changes="$changes ^$unpush"
 		fi
 		if (( $staged > 0 )); then
 			changes="$changes +$staged"

--- a/git-completion.bash
+++ b/git-completion.bash
@@ -33,6 +33,16 @@
 #       are currently in a git repository.  The %s token will be
 #       the name of the current branch.
 #
+#       You can also show current changes adding __git_ps1_changes
+#       to PS1 close to __git_ps1:
+#        ...$(__git_ps1 " (%s)")$(__git_ps1_changes " (%s)")...
+#
+#       Example: ▵2 -+3 *1 ?6 means:
+#        ▵2 - Your branch is ahead of 'origin/branch' by 2 commits
+#        +3 - Your branch has 3 staged changes to be commited
+#        *1 - Your branch has 1 unstaged changes to be commited
+#        ?6 - Your branch has 6 untracked files
+#
 # To submit patches:
 #
 #    *) Read Documentation/SubmittingPatches
@@ -70,6 +80,44 @@ __git_ps1 ()
 			printf "$1" "${b##refs/heads/}"
 		else
 			printf " (%s)" "${b##refs/heads/}"
+		fi
+	fi
+}
+
+__git_ps1_changes ()
+{
+	local b_ref="$(git symbolic-ref HEAD 2>/dev/null)";
+	if [ -n "$b_ref" ]; then
+		local b=${b_ref##refs/heads/};
+		local changes="";
+		local unpush=$(git rev-list origin/$b..$b --count);
+		local staged=$(git diff --staged --name-status | wc -l);
+		local uncommits=$(git status -s -uall --porcelain);
+
+		if (( $unpush > 0 )); then
+			changes="$changes ▵$unpush"
+		fi
+		if (( $staged > 0 )); then
+			changes="$changes +$staged"
+		fi
+
+		local unstaged=$(echo "$uncommits" | grep -c "^ [A-Z]");
+		if (( $unstaged > 0 )); then
+			changes="$changes *$unstaged"
+		fi
+
+		local untracked=$(echo "$uncommits" | grep -c "^??");
+		if (( $untracked > 0 )); then
+			changes="$changes ?$untracked"
+		fi
+
+		changes="$(echo "$changes" | xargs)";
+		if [ -n "$changes" ]; then
+			if [ -n "$1" ]; then
+				printf "$1" "$changes";
+			else
+				printf " %s" "$changes";
+			fi
 		fi
 	fi
 }

--- a/git-completion.bash
+++ b/git-completion.bash
@@ -87,8 +87,8 @@ __git_ps1 ()
 __git_ps1_changes ()
 {
 	local b_ref="$(git symbolic-ref HEAD 2>/dev/null)";
-    local b_origin="$(git for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD))";
 	if [ -n "$b_ref" ]; then
+		local b_origin="$(git for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD))";
 		local b=${b_ref##refs/heads/};
 		local changes="";
 		local unpush=$(git rev-list $b_origin..$b --count);

--- a/git-completion.bash
+++ b/git-completion.bash
@@ -87,37 +87,39 @@ __git_ps1 ()
 __git_ps1_changes ()
 {
 	local b_ref="$(git symbolic-ref -q HEAD 2>/dev/null)";
-	local b_origin="$(git for-each-ref --format='%(upstream:short)' $b_ref)";
-	if [ -n "$b_ref" ] && [ -n "$b_origin" ]; then
-		local b=${b_ref##refs/heads/};
-		local changes="";
-		local unpush=$(git rev-list $b_origin..$b --count);
-		local staged=$(git diff --staged --name-status | wc -l);
-		local uncommits=$(git status -s -uall --porcelain);
+	if [ -n "$b_ref" ]; then
+		local b_origin="$(git for-each-ref --format='%(upstream:short)' $b_ref)";
+		if [ -n "$b_origin" ]; then
+			local b=${b_ref##refs/heads/};
+			local changes="";
+			local unpush=$(git rev-list $b_origin..$b --count);
+			local staged=$(git diff --staged --name-status | wc -l);
+			local uncommits=$(git status -s -uall --porcelain);
 
-		if (( $unpush > 0 )); then
-			changes="$changes ^$unpush"
-		fi
-		if (( $staged > 0 )); then
-			changes="$changes +$staged"
-		fi
+			if (( $unpush > 0 )); then
+				changes="$changes ^$unpush"
+			fi
+			if (( $staged > 0 )); then
+				changes="$changes +$staged"
+			fi
 
-		local unstaged=$(echo "$uncommits" | grep -c "^ [A-Z]");
-		if (( $unstaged > 0 )); then
-			changes="$changes *$unstaged"
-		fi
+			local unstaged=$(echo "$uncommits" | grep -c "^ [A-Z]");
+			if (( $unstaged > 0 )); then
+				changes="$changes *$unstaged"
+			fi
 
-		local untracked=$(echo "$uncommits" | grep -c "^??");
-		if (( $untracked > 0 )); then
-			changes="$changes ?$untracked"
-		fi
+			local untracked=$(echo "$uncommits" | grep -c "^??");
+			if (( $untracked > 0 )); then
+				changes="$changes ?$untracked"
+			fi
 
-		changes="$(echo "$changes" | xargs)";
-		if [ -n "$changes" ]; then
-			if [ -n "$1" ]; then
-				printf "$1" "$changes";
-			else
-				printf " %s" "$changes";
+			changes="$(echo "$changes" | xargs)";
+			if [ -n "$changes" ]; then
+				if [ -n "$1" ]; then
+					printf "$1" "$changes";
+				else
+					printf " %s" "$changes";
+				fi
 			fi
 		fi
 	fi

--- a/git-completion.bash
+++ b/git-completion.bash
@@ -86,9 +86,9 @@ __git_ps1 ()
 
 __git_ps1_changes ()
 {
-	local b_ref="$(git symbolic-ref HEAD 2>/dev/null)";
-	if [ -n "$b_ref" ]; then
-		local b_origin="$(git for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD))";
+	local b_ref="$(git symbolic-ref -q HEAD 2>/dev/null)";
+	local b_origin="$(git for-each-ref --format='%(upstream:short)' $b_ref)";
+	if [ -n "$b_ref" ] && [ -n "$b_origin" ]; then
 		local b=${b_ref##refs/heads/};
 		local changes="";
 		local unpush=$(git rev-list $b_origin..$b --count);


### PR DESCRIPTION
You can also show current changes adding __git_ps1_changes to PS1 close to __git_ps1:
PS1='[\u@\h \W$(__git_ps1 " (%s)")$(__git_ps1_changes " (%s)")]\$ '
## Example:

```
[user@host (master) ^2 +3 *1 ?6]$ 
```

^2 +3 *1 ?6 means:
- ^2  Your branch is ahead of 'origin/branch' by 2 commits
- +3  Your branch has 3 staged changes to be commited
- *1  Your branch has 1 unstaged changes to be commited
- ?6  Your branch has 6 untracked files
